### PR TITLE
Add defaults to the constructor to allow creating the view from code

### DIFF
--- a/draw/src/main/java/com/divyanshu/draw/widget/DrawView.kt
+++ b/draw/src/main/java/com/divyanshu/draw/widget/DrawView.kt
@@ -9,7 +9,9 @@ import android.view.MotionEvent
 import android.view.View
 import java.util.LinkedHashMap
 
-class DrawView(context: Context, attrs: AttributeSet) : View(context, attrs) {
+class DrawView @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
     private var mPaths = LinkedHashMap<MyPath, PaintOptions>()
 
     private var mLastPaths = LinkedHashMap<MyPath, PaintOptions>()


### PR DESCRIPTION
This PR adds support for the other types of constructor which allows the view to be used from code, rather than just from XML layouts.

This is tested as working from both Kotlin and Java.