### PR TITLE
kotlin-android-extensions gradle plugin removed & Kotlin version updated

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'com.android.application'
 
 apply plugin: 'kotlin-android'
 
-apply plugin: 'kotlin-android-extensions'
-
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -20,6 +18,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildFeatures {
+        viewBinding true
+    }
+
 }
 
 dependencies {

--- a/app/src/main/java/com/divyanshu/androiddraw/DrawAdapter.kt
+++ b/app/src/main/java/com/divyanshu/androiddraw/DrawAdapter.kt
@@ -3,16 +3,15 @@ package com.divyanshu.androiddraw
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
-import kotlinx.android.synthetic.main.item_view.view.*
 
 const val IMAGE_PATH = "image_path"
-class DrawAdapter(private val context: Context, private val imageList: ArrayList<String>) : androidx.recyclerview.widget.RecyclerView.Adapter<DrawAdapter.ViewHolder>(){
+class DrawAdapter(private val context: Context, private val imageList: ArrayList<String>) : RecyclerView.Adapter<DrawAdapter.ViewHolder>(){
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(R.layout.item_view,parent,false)
@@ -33,8 +32,8 @@ class DrawAdapter(private val context: Context, private val imageList: ArrayList
         }
     }
 
-    class ViewHolder(itemView: View): androidx.recyclerview.widget.RecyclerView.ViewHolder(itemView) {
-        val drawImage: ImageView = itemView.image_draw
+    class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
+        val drawImage: ImageView = itemView.findViewById(R.id.image_draw)
     }
 
     fun addItem(uri: Uri){

--- a/app/src/main/java/com/divyanshu/androiddraw/ImageActivity.kt
+++ b/app/src/main/java/com/divyanshu/androiddraw/ImageActivity.kt
@@ -3,15 +3,17 @@ package com.divyanshu.androiddraw
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.bumptech.glide.Glide
-import kotlinx.android.synthetic.main.activity_image.*
+import com.divyanshu.androiddraw.databinding.ActivityImageBinding
 
 class ImageActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityImageBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_image)
-
+        binding = ActivityImageBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
         val path = intent.getStringExtra(IMAGE_PATH)
-        Glide.with(this).load(path).into(image_view)
+        Glide.with(this).load(path).into(binding.imageView)
     }
 }

--- a/app/src/main/java/com/divyanshu/androiddraw/MainActivity.kt
+++ b/app/src/main/java/com/divyanshu/androiddraw/MainActivity.kt
@@ -17,8 +17,8 @@ import androidx.core.content.ContextCompat
 import android.util.Log
 import android.view.WindowManager
 import android.widget.EditText
+import com.divyanshu.androiddraw.databinding.ActivityMainBinding
 import com.divyanshu.draw.activity.DrawingActivity
-import kotlinx.android.synthetic.main.activity_main.*
 import java.io.File
 import java.io.FileOutputStream
 import java.util.*
@@ -29,9 +29,13 @@ private const val PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 102
 class MainActivity : AppCompatActivity() {
 
     lateinit var adapter: DrawAdapter
+    private lateinit var binding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
 
         if(ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
             != PackageManager.PERMISSION_GRANTED){
@@ -40,9 +44,9 @@ class MainActivity : AppCompatActivity() {
                     PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE)
         }else{
             adapter = DrawAdapter(this,getFilesPath())
-            recycler_view.adapter = adapter
+            binding.recyclerView.adapter = adapter
         }
-        fab_add_draw.setOnClickListener {
+        binding.fabAddDraw.setOnClickListener {
             val intent = Intent(this, DrawingActivity::class.java)
             startActivityForResult(intent, REQUEST_CODE_DRAW)
         }
@@ -65,7 +69,7 @@ class MainActivity : AppCompatActivity() {
             when(requestCode){
                 REQUEST_CODE_DRAW -> {
                     val result= data.getByteArrayExtra("bitmap")
-                    val bitmap = BitmapFactory.decodeByteArray(result, 0, result.size)
+                    val bitmap = BitmapFactory.decodeByteArray(result, 0, result!!.size)
                     showSaveDialog(bitmap)
                 }
             }
@@ -85,7 +89,7 @@ class MainActivity : AppCompatActivity() {
                 .setNegativeButton("Cancel") { _, _ -> }
 
         val dialog = alertDialog.create()
-        dialog.window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
         dialog.show()
     }
 
@@ -94,7 +98,7 @@ class MainActivity : AppCompatActivity() {
             PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE -> {
                 if ((grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)){
                     adapter = DrawAdapter(this,getFilesPath())
-                    recycler_view.adapter = adapter
+                    binding.recyclerView.adapter = adapter
                 }else{
                     finish()
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.10'
+    ext.kotlin_version = '1.5.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Since the 'kotlin-android-extensions' Gradle plugin is deprecated. Migrated synthetics to view binding.
